### PR TITLE
chore: update npm guide with accurate information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.idea
 
 npm-debug.log*
 yarn-debug.log*

--- a/README.md
+++ b/README.md
@@ -53,9 +53,7 @@ For more guides and how to set up different aspects of the service [please refer
 ## Migrate from older versions
 
 ### v5 to v6
-
 If you come from v5 you might be used to chibisafe exposing 1 single port for you to reverse proxy into nginx/caddy/apache. Starting from v6 this is also the case (although port is now 24424) as long as you run the configuration we provide with docker. Other than configuring your reverse proxy accordingly, all you need to do to migrate is to copy both the `uploads/` and `database/` folders into your new instance folder. Once chibisafe starts it will apply the necessary migrations automatically.
-</details>
 
 > [!CAUTION]
 > Migrating from an older version than v5 to v6 is not possible, so we recommend setting up a new instance instead.
@@ -71,7 +69,6 @@ If you come from v5 you might be used to chibisafe exposing 1 single port for yo
 </p>
 
 ## Author
-
 **Chibisafe** © [Pitu](https://github.com/Pitu), Released under the [MIT](https://github.com/WeebDev/chibisafe/blob/master/LICENSE) License.<br>
 Authored and maintained by Pitu.
 

--- a/docs/installation/running-with-docker-npm.md
+++ b/docs/installation/running-with-docker-npm.md
@@ -1,28 +1,28 @@
 ---
 title: Running with Docker and Nginx Proxy Manager
-summary: This guide shows you how to run chibisafe with Nginx Proxy Manager (or NPM) through Docker without the internal Caddy server.
+summary: This guide shows you how to run Chibisafe with Nginx Proxy Manager (or NPM) through Docker without the internal Caddy server.
 ---
 
-# Running chibisafe with Nginx Proxy Manager through Docker
-> This guide shows you how to run chibisafe with Nginx Proxy Manager (or NPM) through Docker without the internal Caddy server.
+# Running Chibisafe with Nginx Proxy Manager through Docker
+> This guide shows you how to run Chibisafe with Nginx Proxy Manager (or NPM) through Docker without the internal Caddy server.
 
-In order to install chibisafe and run it with Nginx Proxy Manager there are a few things you need to set up on your system beforehand. This guide assumes you are using Ubuntu/Debian so feel free to adjust commands as you see fit based on your distro.
+In order to install Chibisafe and run it with Nginx Proxy Manager there are a few things you need to set up on your system beforehand. This guide assumes you are using Ubuntu/Debian so feel free to adjust commands as you see fit based on your distro.
 
 :::tip
-  This guide assumes you are an advanced user. If you are not familiar with Docker, Nginx Proxy Manager and development in general, please install chibisafe normally through docker and follow the [official guide](/docs/installation/running-with-docker).
+  This guide assumes you are an advanced user. If you are not familiar with Docker, Nginx Proxy Manager and development in general, please install Chibisafe normally through docker and follow the [official guide](/docs/installation/running-with-docker).
 :::
 
 ### Pre-requisites
 
-Before running chibisafe make sure you install docker and docker-compose. Please refer to the [official Docker documentation](https://docs.docker.com/get-docker/) for installation instructions.
+Before running Chibisafe make sure you install docker and docker-compose. Please refer to the [official Docker documentation](https://docs.docker.com/get-docker/) for installation instructions.
 
-You will need to setup Nginx Proxy Manager as well, on port 80, 443 and 81. Go to the [official Nginx Proxy Manager documentation](https://nginxproxymanager.com/guide/#quick-setup) for installation instructions.
+You will need to set up Nginx Proxy Manager as well, on port 80, 443 and 81. Go to the [official Nginx Proxy Manager documentation](https://nginxproxymanager.com/guide/#quick-setup) for installation instructions.
 
 You will also need a FQDN (Fully Qualified Domain Name) pointing to your server. You can use a service like [Cloudflare](https://www.cloudflare.com/) to get a domain.
 
 ### Installing
 
-This guide assumes you will use Docker to run chibisafe. If you want to run it manually, just follow the [manual guide](/docs/installation/running-manually) and install Nginx Proxy Manager like we said.
+This guide assumes you will use Docker to run Chibisafe. If you want to run it manually, just follow the [manual guide](/docs/installation/running-manually) and install Nginx Proxy Manager like we said.
 
 First, move to a place where you can install it:
 
@@ -31,11 +31,11 @@ cd /home/<your user>
 ```
 
 :::tip
-  As Docker *by default* does not run as your user, this *may not* be the best location to put chibisafe in.
-  The more "appropriate" location would be on `/srv`, so change the place where chibisafe is installed accordingly if you want to follow best practices.
+  As Docker *by default* does not run as your user, this *may not* be the best location to put Chibisafe in.
+  The more "appropriate" location would be on `/srv`, so change the place where Chibisafe is installed accordingly if you want to follow best practices.
 :::
 
-Then, make a directory for chibisafe and move to it:
+Then, make a directory for Chibisafe and move to it:
 
 ```bash
 mkdir chibisafe
@@ -75,29 +75,29 @@ services:
 > We removed the caddy section, as we won't need it. We also exposed to the host the ports 8000 and 8001, so Nginx Proxy Manager can access them.
 
 :::tip
-  In this changes, we removed the static file serving. You will need to serve your chibisafe files from a different location with either a web server or a Docker container image that allows this, and then configure chibisafe accordingly.
+  In these changes, we removed the static file serving. You will need to serve your Chibisafe files from a different location with either a web server or a Docker container image that allows this, and then configure Chibisafe accordingly.
   Head over to the [file serving](#serve-the-uploads) section for more information on how to do this.
 :::
 
-Now, you can run `docker-compose up -d` to start chibisafe.
+Now, you can run `docker-compose up -d` to start Chibisafe.
 
 :::tip
-  This way of hosting chibisafe will NOT allow you to customize the ports which chibisafe listens on. So if anything (like portainer) uses the `8000` and `8001` port, you'll get an error and will need to change the port the other thing listening on 8000 and 8001 uses.
-  If you want to customize them, you will need to edit the chibisafe source code to change environment variables, and then either build a local docker image to run it or run it manually.
+  This way of hosting Chibisafe will NOT allow you to customize the ports which Chibisafe listens on. So if anything (like portainer) uses the `8000` and `8001` port, you'll get an error and will need to change the port the other thing listening on 8000 and 8001 uses.
+  If you want to customize them, you will need to edit the Chibisafe source code to change environment variables, and then either build a local docker image to run it or run it manually.
 :::
 
 ### Configuring Nginx Proxy Manager
 
-Now, you need to configure Nginx Proxy Manager to proxy the requests to chibisafe. Go to your Nginx Proxy Manager instance and add a new proxy host.
+Now, you need to configure Nginx Proxy Manager to proxy the requests to Chibisafe. Go to your Nginx Proxy Manager instance and add a new proxy host.
 
 - **Domain Names**: Your domain name (e.g. chibisafe.example.com)
 - **Scheme**: http
 - **Forward Hostname/IP**: \<your local ip or public ip\>
 - **Forward Port**: 8001
 
-> Don't forget to enable `cache assets`, `websockets support` and configure an SSL certificate (also enable `force ssl`). You can use Let's Encrypt for that.
+> Don't forget to enable `cache assets` and configure an SSL certificate (also enable `force ssl`). You can use Let's Encrypt for that.
 
-Then, head over to the location tab and add a two new locations:
+Then, head over to the location tab and add two new locations:
 
 - **location**: /api
 - **scheme**: http
@@ -119,7 +119,7 @@ Now, you need to configure your DNS to point to your server. You can use Cloudfl
 
 ### Serve the uploads
 
-As we just saw before, in the [docker-compose.yml](#installing) file we removed the static file serving. You will need to serve your chibisafe files from a different location with either a web server or a Docker container image that allows this, and then configure chibisafe accordingly.
+As we just saw before, in the [docker-compose.yml](#installing) file we removed the static file serving. You will need to serve your Chibisafe files from a different location with either a web server or a Docker container image that allows this, and then configure Chibisafe accordingly.
 
 Here is an example on how to serve the files with a docker image file server:
 
@@ -133,6 +133,9 @@ services:
       - "8002:8080"
     volumes:
       - "./uploads:/web"
+    environment:
+      - ALLOW_INDEX=false
+      - SHOW_LISTING=false
 
   chibisafe:
     image: chibisafe/chibisafe:latest
@@ -157,9 +160,9 @@ services:
       - 8000:8000
 ```
 
-Here is our new docker-compose.yml file that will run both chibisafe and the file server. The file server will serve the files from the `uploads` folder and listen on port 8002, so make sure to not have anything on that port. you can change the port if you want.
+Here is our new docker-compose.yml file that will run both Chibisafe and the file server. The file server will serve the files from the `uploads` folder and listen on port 8002, so make sure to not have anything on that port. you can change the port if you want.
 
-Now, you can run `docker-compose up -d` to start chibisafe and the file server.
+Now, you can run `docker-compose up -d` to start Chibisafe and the file server.
 
 Now we need to configure Nginx Proxy Manager to proxy the requests to the file server. Go to your Nginx Proxy Manager instance and add a new proxy host:
 
@@ -172,10 +175,10 @@ Now we need to configure Nginx Proxy Manager to proxy the requests to the file s
 
 You can now save the configuration and wait for Nginx Proxy Manager to apply the changes.
 
-Then, head over to your chibisafe installation, as some changes must be made. Go to dashboard -> settings -> service and change the `Serve Uploads From` to your file server domain (e.g. `https://files.example.com`). Don't forget the http:// or https://!
+Then, head over to your Chibisafe installation, as some changes must be made. Go to dashboard -> settings -> service and change the `Serve Uploads From` to your file server domain (e.g. `https://files.example.com`). Don't forget the http:// or https://!
 
-This change may need a restart so feel free to restart your chibisafe instance by heading over to where your docker-compose.yml file is and running `docker-compose down && docker-compose up -d`.
+This change may need a restart so feel free to restart your Chibisafe instance by heading over to where your docker-compose.yml file is and running `docker-compose down && docker-compose up -d`.
 
 ### Done!
 
-You can now access chibisafe through your domain name. If you have any issues, feel free to ask for help in our [Discord server](https://discord.gg/5g6vgwn).
+You can now access Chibisafe through your domain name. If you have any issues, feel free to ask for help in our [Discord server](https://discord.gg/5g6vgwn).

--- a/docs/installation/running-with-docker-npm.md
+++ b/docs/installation/running-with-docker-npm.md
@@ -1,20 +1,20 @@
 ---
 title: Running with Docker and Nginx Proxy Manager
-summary: This guide shows you how to run Chibisafe with Nginx Proxy Manager (or NPM) through Docker without the internal Caddy server.
+summary: This guide shows you how to run chibisafe with Nginx Proxy Manager (or NPM) through Docker without the internal Caddy server.
 ---
 
-# Running Chibisafe with Nginx Proxy Manager through Docker
-> This guide shows you how to run Chibisafe with Nginx Proxy Manager (or NPM) through Docker without the internal Caddy server.
+# Running chibisafe with Nginx Proxy Manager through Docker
+> This guide shows you how to run chibisafe with Nginx Proxy Manager (or NPM) through Docker without the internal Caddy server.
 
-In order to install Chibisafe and run it with Nginx Proxy Manager there are a few things you need to set up on your system beforehand. This guide assumes you are using Ubuntu/Debian so feel free to adjust commands as you see fit based on your distro.
+In order to install chibisafe and run it with Nginx Proxy Manager there are a few things you need to set up on your system beforehand. This guide assumes you are using Ubuntu/Debian so feel free to adjust commands as you see fit based on your distro.
 
 :::tip
-  This guide assumes you are an advanced user. If you are not familiar with Docker, Nginx Proxy Manager and development in general, please install Chibisafe normally through docker and follow the [official guide](/docs/installation/running-with-docker).
+  This guide assumes you are an advanced user. If you are not familiar with Docker, Nginx Proxy Manager and development in general, please install chibisafe normally through docker and follow the [official guide](/docs/installation/running-with-docker).
 :::
 
 ### Pre-requisites
 
-Before running Chibisafe make sure you install docker and docker-compose. Please refer to the [official Docker documentation](https://docs.docker.com/get-docker/) for installation instructions.
+Before running chibisafe make sure you install docker and docker-compose. Please refer to the [official Docker documentation](https://docs.docker.com/get-docker/) for installation instructions.
 
 You will need to set up Nginx Proxy Manager as well, on port 80, 443 and 81. Go to the [official Nginx Proxy Manager documentation](https://nginxproxymanager.com/guide/#quick-setup) for installation instructions.
 
@@ -22,7 +22,7 @@ You will also need a FQDN (Fully Qualified Domain Name) pointing to your server.
 
 ### Installing
 
-This guide assumes you will use Docker to run Chibisafe. If you want to run it manually, just follow the [manual guide](/docs/installation/running-manually) and install Nginx Proxy Manager like we said.
+This guide assumes you will use Docker to run chibisafe. If you want to run it manually, just follow the [manual guide](/docs/installation/running-manually) and install Nginx Proxy Manager like we said.
 
 First, move to a place where you can install it:
 
@@ -31,11 +31,11 @@ cd /home/<your user>
 ```
 
 :::tip
-  As Docker *by default* does not run as your user, this *may not* be the best location to put Chibisafe in.
-  The more "appropriate" location would be on `/srv`, so change the place where Chibisafe is installed accordingly if you want to follow best practices.
+  As Docker *by default* does not run as your user, this *may not* be the best location to put chibisafe in.
+  The more "appropriate" location would be on `/srv`, so change the place where chibisafe is installed accordingly if you want to follow best practices.
 :::
 
-Then, make a directory for Chibisafe and move to it:
+Then, make a directory for chibisafe and move to it:
 
 ```bash
 mkdir chibisafe
@@ -75,20 +75,20 @@ services:
 > We removed the caddy section, as we won't need it. We also exposed to the host the ports 8000 and 8001, so Nginx Proxy Manager can access them.
 
 :::tip
-  In these changes, we removed the static file serving. You will need to serve your Chibisafe files from a different location with either a web server or a Docker container image that allows this, and then configure Chibisafe accordingly.
+  In these changes, we removed the static file serving. You will need to serve your chibisafe files from a different location with either a web server or a Docker container image that allows this, and then configure chibisafe accordingly.
   Head over to the [file serving](#serve-the-uploads) section for more information on how to do this.
 :::
 
-Now, you can run `docker-compose up -d` to start Chibisafe.
+Now, you can run `docker-compose up -d` to start chibisafe.
 
 :::tip
-  This way of hosting Chibisafe will NOT allow you to customize the ports which Chibisafe listens on. So if anything (like portainer) uses the `8000` and `8001` port, you'll get an error and will need to change the port the other thing listening on 8000 and 8001 uses.
-  If you want to customize them, you will need to edit the Chibisafe source code to change environment variables, and then either build a local docker image to run it or run it manually.
+  This way of hosting chibisafe will NOT allow you to customize the ports which chibisafe listens on. So if anything (like portainer) uses the `8000` and `8001` port, you'll get an error and will need to change the port the other thing listening on 8000 and 8001 uses.
+  If you want to customize them, you will need to edit the chibisafe source code to change environment variables, and then either build a local docker image to run it or run it manually.
 :::
 
 ### Configuring Nginx Proxy Manager
 
-Now, you need to configure Nginx Proxy Manager to proxy the requests to Chibisafe. Go to your Nginx Proxy Manager instance and add a new proxy host.
+Now, you need to configure Nginx Proxy Manager to proxy the requests to chibisafe. Go to your Nginx Proxy Manager instance and add a new proxy host.
 
 - **Domain Names**: Your domain name (e.g. chibisafe.example.com)
 - **Scheme**: http
@@ -119,7 +119,7 @@ Now, you need to configure your DNS to point to your server. You can use Cloudfl
 
 ### Serve the uploads
 
-As we just saw before, in the [docker-compose.yml](#installing) file we removed the static file serving. You will need to serve your Chibisafe files from a different location with either a web server or a Docker container image that allows this, and then configure Chibisafe accordingly.
+As we just saw before, in the [docker-compose.yml](#installing) file we removed the static file serving. You will need to serve your chibisafe files from a different location with either a web server or a Docker container image that allows this, and then configure chibisafe accordingly.
 
 Here is an example on how to serve the files with a docker image file server:
 
@@ -160,9 +160,9 @@ services:
       - 8000:8000
 ```
 
-Here is our new docker-compose.yml file that will run both Chibisafe and the file server. The file server will serve the files from the `uploads` folder and listen on port 8002, so make sure to not have anything on that port. you can change the port if you want.
+Here is our new docker-compose.yml file that will run both chibisafe and the file server. The file server will serve the files from the `uploads` folder and listen on port 8002, so make sure to not have anything on that port. you can change the port if you want.
 
-Now, you can run `docker-compose up -d` to start Chibisafe and the file server.
+Now, you can run `docker-compose up -d` to start chibisafe and the file server.
 
 Now we need to configure Nginx Proxy Manager to proxy the requests to the file server. Go to your Nginx Proxy Manager instance and add a new proxy host:
 
@@ -175,10 +175,10 @@ Now we need to configure Nginx Proxy Manager to proxy the requests to the file s
 
 You can now save the configuration and wait for Nginx Proxy Manager to apply the changes.
 
-Then, head over to your Chibisafe installation, as some changes must be made. Go to dashboard -> settings -> service and change the `Serve Uploads From` to your file server domain (e.g. `https://files.example.com`). Don't forget the http:// or https://!
+Then, head over to your chibisafe installation, as some changes must be made. Go to dashboard -> settings -> service and change the `Serve Uploads From` to your file server domain (e.g. `https://files.example.com`). Don't forget the http:// or https://!
 
-This change may need a restart so feel free to restart your Chibisafe instance by heading over to where your docker-compose.yml file is and running `docker-compose down && docker-compose up -d`.
+This change may need a restart so feel free to restart your chibisafe instance by heading over to where your docker-compose.yml file is and running `docker-compose down && docker-compose up -d`.
 
 ### Done!
 
-You can now access Chibisafe through your domain name. If you have any issues, feel free to ask for help in our [Discord server](https://discord.gg/5g6vgwn).
+You can now access chibisafe through your domain name. If you have any issues, feel free to ask for help in our [Discord server](https://discord.gg/5g6vgwn).


### PR DESCRIPTION
I modified the running with docker and nginx proxy manager guide with accurate information (removed the websocket requirement, which is useless).
I also added .idea to gitignore, as otherwise I would be commiting my IDE files, that are more than useless here.
Also removed the </details> tag in the README as it was closing nothing.