### PR TITLE
Update domains to RFC6761 complient example.com domains.

### DIFF
--- a/docs/installation/running-manually.md
+++ b/docs/installation/running-manually.md
@@ -88,7 +88,7 @@ If you rather use PM2 what you can do is create a file called `chibisafe.json` i
 ```
 
 :::tip
-  Make sure to change chibi.domain for your own domain name.
+  Make sure to change your-chibi-domain.example.com for your own domain name.
 :::
 
 Now you can run the following command and chibisafe will run in the background
@@ -102,7 +102,7 @@ In order to make chibisafe's 2 processes usable and attach a domain name, you ne
 Once you have Caddy installed locally you can add this to your Caddyfile in order reverse proxy the exposed ports from chibisafe:
 
 ```caddy title="/etc/caddy/Caddyfile"
-chibi.domain {
+your-chibi-domain.example.com {
 	route {
 		file_server * {
 			root /app/uploads
@@ -127,10 +127,10 @@ chibi.domain {
 ```
 
 Nginx config example:
-```nginx title="/etc/nginx/sites-available/chibi.domain"
+```nginx title="/etc/nginx/sites-available/your-chibi-domain.example.com"
 server {
     listen 80;
-    server_name chibi.domain;
+    server_name your-chibi-domain.example.com;
 
     root /app/uploads;
 
@@ -162,7 +162,7 @@ server {
 }
 ```
 :::tip
-  Make sure to change chibi.domain for your own domain name, and `root /app/uploads` for the actual path where your upload folder is.
+  Make sure to change your-chibi-domain.example.com for your own domain name, and `root /app/uploads` for the actual path where your upload folder is.
 :::
 
 After correctly setting your Caddyfile and restarting the caddy process in your system, you should be able to visit your instance with the domain name and start using it.

--- a/docs/installation/running-with-docker-traefik-and-nginx.md
+++ b/docs/installation/running-with-docker-traefik-and-nginx.md
@@ -7,7 +7,7 @@ sidebar_position: 4
 This guide provides detailed steps to deploy **chibisafe** using Docker, Traefik, and NGINX. It assumes that you have Docker, Docker Compose, and a running Traefik instance already installed and configured. If you don't have a Traefik installation, please refer to the [official Traefik documentation](https://doc.traefik.io/traefik).
 
 > **Important:**  
-> Replace all instances of `your-domain-name.com` and `cdn.your-domain-name.com` with your actual domain names to ensure correct routing and SSL certificate issuance.
+> Replace all instances of `your-chibi-domain.example.com` and `cdn.your-chibi-domain.example.com` with your actual domain names to ensure correct routing and SSL certificate issuance.
 
 ## Prerequisites
 
@@ -54,13 +54,13 @@ services:
       # HTTP Router
       traefik.http.routers.chibisafe-http.entrypoints: web
       traefik.http.routers.chibisafe-http.middlewares: globalHeaders@file,redirect-to-https@docker,robotHeaders@file # Optional
-      traefik.http.routers.chibisafe-http.rule: Host(`your-domain-name.com`) && !PathPrefix(`/api`) && !PathPrefix(`/docs`)
+      traefik.http.routers.chibisafe-http.rule: Host(`your-chibi-domain.example.com`) && !PathPrefix(`/api`) && !PathPrefix(`/docs`)
       traefik.http.routers.chibisafe-http.service: chibisafe
 
       # HTTPS Router (Secure)
       traefik.http.routers.chibisafe.entrypoints: websecure
       traefik.http.routers.chibisafe.middlewares: globalHeaders@file,secureHeaders@file,robotHeaders@file # Optional
-      traefik.http.routers.chibisafe.rule: Host(`your-domain-name.com`) && !PathPrefix(`/api`) && !PathPrefix(`/docs`)
+      traefik.http.routers.chibisafe.rule: Host(`your-chibi-domain.example.com`) && !PathPrefix(`/api`) && !PathPrefix(`/docs`)
       traefik.http.routers.chibisafe.service: chibisafe
       traefik.http.routers.chibisafe.tls.certresolver: cfdns # Alternatively, you can use letsencrypt
       traefik.http.routers.chibisafe.tls.options: securetls@file
@@ -81,13 +81,13 @@ services:
       # HTTP Router
       traefik.http.routers.chibisafe-server-http.entrypoints: web
       traefik.http.routers.chibisafe-server-http.middlewares: globalHeaders@file,redirect-to-https@docker,robotHeaders@file # Optional
-      traefik.http.routers.chibisafe-server-http.rule: Host(`your-domain-name.com`) && (PathPrefix(`/api`) || PathPrefix(`/docs`))
+      traefik.http.routers.chibisafe-server-http.rule: Host(`your-chibi-domain.example.com`) && (PathPrefix(`/api`) || PathPrefix(`/docs`))
       traefik.http.routers.chibisafe-server-http.service: chibisafe-server
 
       # HTTPS Router (Secure)
       traefik.http.routers.chibisafe-server.entrypoints: websecure
       traefik.http.routers.chibisafe-server.middlewares: globalHeaders@file,secureHeaders@file,robotHeaders@file
-      traefik.http.routers.chibisafe-server.rule: Host(`your-domain-name.com`) && (PathPrefix(`/api`) || PathPrefix(`/docs`)) # Optional
+      traefik.http.routers.chibisafe-server.rule: Host(`your-chibi-domain.example.com`) && (PathPrefix(`/api`) || PathPrefix(`/docs`)) # Optional
       traefik.http.routers.chibisafe-server.service: chibisafe-server
       traefik.http.routers.chibisafe-server.tls.certresolver: cfdns # Alternatively, you can use letsencrypt
       traefik.http.routers.chibisafe-server.tls.options: securetls@file
@@ -113,13 +113,13 @@ services:
       # HTTP Router
       traefik.http.routers.chibisafe-cdn-http.entrypoints: web
       traefik.http.routers.chibisafe-cdn-http.middlewares: globalHeaders@file,redirect-to-https@docker,robotHeaders@file # Optional
-      traefik.http.routers.chibisafe-cdn-http.rule: Host(`cdn.your-domain-name.com`) # Make sure to set this as "Serve Uploads From" in settings later.
+      traefik.http.routers.chibisafe-cdn-http.rule: Host(`cdn.your-chibi-domain.example.com`) # Make sure to set this as "Serve Uploads From" in settings later.
       traefik.http.routers.chibisafe-cdn-http.service: chibisafe-cdn
 
       # HTTPS Router (Secure)
       traefik.http.routers.chibisafe-cdn.entrypoints: websecure
       traefik.http.routers.chibisafe-cdn.middlewares: globalHeaders@file,secureHeaders@file,robotHeaders@file # Optional
-      traefik.http.routers.chibisafe-cdn.rule: Host(`cdn.your-domain-name.com`) # Make sure to set this as "Serve Uploads From" in settings later.
+      traefik.http.routers.chibisafe-cdn.rule: Host(`cdn.your-chibi-domain.example.com`) # Make sure to set this as "Serve Uploads From" in settings later.
       traefik.http.routers.chibisafe-cdn.service: chibisafe-cdn
       traefik.http.routers.chibisafe-cdn.tls.certresolver: cfdns # Alternatively, you can use letsencrypt
       traefik.http.routers.chibisafe-cdn.tls.options: securetls@file

--- a/docs/installation/running-with-docker.md
+++ b/docs/installation/running-with-docker.md
@@ -119,7 +119,7 @@ In order to attach a domain name to an application running with an exposed port 
 Once you have Caddy installed locally you can add this to your Caddyfile in order reverse proxy the exposed port from chibisafe:
 
 ```caddy title="/etc/caddy/Caddyfile"
-your-chibisafe-domain.com {
+your-chibi-domain.example.com {
 	reverse_proxy localhost:24424
 }
 ```
@@ -127,7 +127,7 @@ your-chibisafe-domain.com {
 If you use Cloudflare or a similar service and want your instance to be proxied by them, you should instead use the one below since it adds the necessary headers to pass the visitor's IP to the chibisafe instance. Note that the trusted proxies and X-Forwarded-For headers are specifically made for use with Cloudflare and will require modification for other proxies.
 
 ```caddy title="/etc/caddy/Caddyfile"
-your-chibisafe-domain.com {
+your-chibi-domain.example.com {
 	tls internal
 	reverse_proxy localhost:24424 {
 		trusted_proxies 173.245.48.0/20 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22 141.101.64.0/18 108.162.192.0/18 190.93.240.0/20 188.114.96.0/20 197.234.240.0/22 198.41.128.0/17 162.158.0.0/15 104.16.0.0/13 104.24.0.0/14 172.64.0.0/13 131.0.72.0/22 2400:cb00::/32 2606:4700::/32 2803:f800::/32 2405:b500::/32 2405:8100::/32 2a06:98c0::/29 2c0f:f248::/32
@@ -146,7 +146,7 @@ Configuring Nginx is more difficult so we're only providing with a skeleton conf
 # Chibisafe Reverse Proxy
 
 server {
-	server_name chibi.domain;
+	server_name your-chibi-domain.example.com;
 	listen [::]:443 ssl;
 	listen 443 ssl;
 
@@ -166,7 +166,7 @@ server {
 ```
 
 :::tip 
-  Make sure to change chibi.domain for your own domain name.
+  Make sure to change your-chibi-domain.example.com for your own domain name.
 :::
 
 

--- a/docs/uploaders/obsidian-image-uploader.md
+++ b/docs/uploaders/obsidian-image-uploader.md
@@ -20,7 +20,7 @@ Now go the plugin settings and fill the following information:
 
 - Api Endpoint
 ```
-https://your-chibisafe-full-domain/api/upload
+https://your-chibi-domain.example.com/api/upload
 ```
 - Upload Header
 ```json

--- a/docs/uploaders/using-fswatch.md
+++ b/docs/uploaders/using-fswatch.md
@@ -12,7 +12,7 @@ Not all screenshot utilities allow you to upload images directly to alternative 
 1. The **`fswatch` binary**.  
 Project Page: [emcrisostomo/fswatch](https://github.com/emcrisostomo/fswatch)
 2. Your **Request URL**.  
-Example: `https://foo.bar/api/upload`
+Example: `https://your-chibi-domain.example.com/api/upload`
 3. Your **API Key**.  
 Example: `GI4nAlK6gwy8T2BvmP31ZwaNbtgxACbXxQZb3nUiLcpPanl03f6WKxuaBkMfMy1C`
 4. The **directory** where you want to **watch** for changes  
@@ -40,7 +40,7 @@ touch chibisafe_watcher.env
 Open `chibisafe_watcher.env` with your favorite editor and paste the following content, and replace the values with your own:
 
 ```sh
-CHIBISAFE_REQUEST_URL=https://foo.bar/api/upload
+CHIBISAFE_REQUEST_URL=https://your-chibi-domain.example.com/api/upload
 CHIBISAFE_API_KEY=GI4nAlK6gwy8T2BvmP31ZwaNbtgxACbXxQZb3nUiLcpPanl03f6WKxuaBkMfMy1C
 CHIBISAFE_WATCH_DIR=/home/catbox/screenshots/
 

--- a/docs/uploaders/using-mac-os-native.md
+++ b/docs/uploaders/using-mac-os-native.md
@@ -1,10 +1,10 @@
 # macOS Screenshot Auto-Upload Guide
 
-This guide will help you set up an **automatic screenshot upload system** on macOS using the shortcut **Command + Shift + =**. Once set up, pressing this shortcut will take a screenshot, upload it to `https://your.chibi.domain.com/api/upload`, and copy the image URL to your clipboard.
+This guide will help you set up an **automatic screenshot upload system** on macOS using the shortcut **Command + Shift + =**. Once set up, pressing this shortcut will take a screenshot, upload it to `https://your-chibi-domain.example.com/api/upload`, and copy the image URL to your clipboard.
 
 ## Features
 ✅ **Global shortcut (Command + Shift + =) to take & upload screenshots**  
-✅ **Automatic upload to `https://your.chibi.domain.com/api/upload`**  
+✅ **Automatic upload to `https://your-chibi-domain.example.com/api/upload`**  
 ✅ **Copy the uploaded image URL to the clipboard**  
 ✅ **macOS notifications for success or failure**
 
@@ -23,7 +23,7 @@ This guide will help you set up an **automatic screenshot upload system** on mac
    
    # Configuration
    API_KEY="YOUR_API_KEY_HERE" #Put the api key from `Dashboard -> Credentials -> API Key` here
-   UPLOAD_URL="https://your.chibi.domain.com/api/upload" #Please change `your.chibi.domain.com` to your domain for your instance
+   UPLOAD_URL="https://your-chibi-domain.example.com/api/upload" #Please change `your-chibi-domain.example.com` to your domain for your instance
    SCREENSHOT_PATH="$HOME/Desktop/screenshot_$(date +%Y-%m-%d_%H-%M-%S).png"
    
    # Take Screenshot (Interactive Mode)
@@ -45,7 +45,7 @@ This guide will help you set up an **automatic screenshot upload system** on mac
    # Optional: Delete the screenshot after upload
    rm "$SCREENSHOT_PATH"
    ```
-4. **Please MAKE SURE TO CHANGE `your.chibi.domain.com` to your actual domain for your chibisafe instance!**
+4. **Please MAKE SURE TO CHANGE `your-chibi-domain.example.com` to your actual domain for your chibisafe instance!**
 5. **Save and exit**:
     - Press `CTRL + X`, then `Y`, then `Enter`.
 5. **Make it executable**:
@@ -97,12 +97,12 @@ This guide will help you set up an **automatic screenshot upload system** on mac
 ## 🚀 Usage
 Now, whenever you press `⌘ + ⇧ + =`, macOS will:
 ✅ **Capture a screenshot interactively**.  
-✅ **Upload it automatically** to `https://your.chibi.domain.com/api/upload`.  
+✅ **Upload it automatically** to `https://your-chibi-domain.example.com/api/upload`.  
 ✅ **Copy the uploaded image URL** to your clipboard.  
 ✅ **Show a success/failure notification**.  
 ✅ **Work globally in any app**.
 
 This setup ensures a **seamless screenshot upload process**! 🚀
 
-**Please MAKE SURE TO CHANGE `your.chibi.domain.com` to your actual domain for your chibisafe instance!**
+**Please MAKE SURE TO CHANGE `your-chibi-domain.example.com` to your actual domain for your chibisafe instance!**
 


### PR DESCRIPTION
Update example domains to example.com as per RFC6761 to prevent accidental data leakage if default config unchanged.